### PR TITLE
feat: VSCode開発環境設定の追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,91 @@
     {
       "mode": "auto"
     }
-  ]
+  ],
+  "cSpell.language": "en,ja",
+  "cSpell.enabledFileTypes": [
+    "markdown",
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "json",
+    "yaml",
+    "html",
+    "css",
+    "scss"
+  ],
+  "cSpell.words": [
+    "turbo",
+    "turborepo",
+    "pnpm",
+    "monorepo",
+    "tsuka",
+    "ryu",
+    "tsukaryu",
+    "vitest",
+    "oxlint",
+    "commitlint",
+    "husky",
+    "precommit",
+    "docusaurus",
+    "nextjs",
+    "esbenp"
+  ],
+  "cSpell.ignorePaths": [
+    "node_modules",
+    "pnpm-lock.yaml",
+    ".git",
+    ".turbo",
+    ".next",
+    "dist",
+    "build",
+    "coverage"
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[scss]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "eslint.validate": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact"
+  ],
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,18 +5,18 @@
     }
   ],
   "cSpell.language": "en,ja",
-  "cSpell.enabledFileTypes": [
-    "markdown",
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact",
-    "json",
-    "yaml",
-    "html",
-    "css",
-    "scss"
-  ],
+  "cSpell.enabledFileTypes": {
+    "markdown": true,
+    "javascript": true,
+    "javascriptreact": true,
+    "typescript": true,
+    "typescriptreact": true,
+    "json": true,
+    "yaml": true,
+    "html": true,
+    "css": true,
+    "scss": true
+  },
   "cSpell.words": [
     "turbo",
     "turborepo",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -88,12 +88,7 @@
   "[scss]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -32,7 +32,12 @@
     "precommit",
     "docusaurus",
     "nextjs",
-    "esbenp"
+    "esbenp",
+    "lefthook",
+    "Monospace",
+    "Shiki",
+    "WCAG",
+    "giscus"
   ],
   "cSpell.ignorePaths": [
     "node_modules",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     "nextjs",
     "esbenp",
     "lefthook",
+    "Monaspace",
     "Monospace",
     "Shiki",
     "WCAG",


### PR DESCRIPTION
## Summary
- VSCode用の包括的な開発環境設定を追加
- スペルチェッカーの設定（日本語・英語対応、プロジェクト固有の辞書）
- 保存時の自動フォーマット設定（ESLint自動修正、Prettier自動フォーマット）

## Changes
- `.vscode/settings.json`を拡張:
  - cSpell（スペルチェッカー）の設定を追加
  - 保存時のコードアクション設定（ESLint自動修正）
  - 各言語ごとのデフォルトフォーマッター設定（Prettier）
  - TypeScript SDKの設定

## Test plan
- [ ] VSCodeでファイルを開いて、スペルチェッカーが正しく動作することを確認
- [ ] TypeScript/JavaScriptファイルを保存して、自動フォーマットが実行されることを確認
- [ ] ESLintの警告があるファイルを保存して、自動修正が動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)