### PR TITLE
fix: ブログ記事の作者名を修正

### DIFF
--- a/apps/docs/blog/2025-06-14-dependency-management-strategies.md
+++ b/apps/docs/blog/2025-06-14-dependency-management-strategies.md
@@ -1,7 +1,7 @@
 ---
 slug: dependency-management-strategies
 title: モノレポでの依存関係管理戦略：5つのアプローチ比較
-authors: [tsukaryu]
+authors: [tsuka-ryu]
 tags: [pnpm, monorepo, dependency-management, renovate, automation]
 ---
 


### PR DESCRIPTION
## Summary
• ブログ記事の作者名を`tsukaryu`から`tsuka-ryu`に修正

## Test plan
- [x] コミット後のリントとタイプチェックが正常に完了
- [x] メタデータの変更のみで機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)