### PR TITLE
fix(docs): Docusaurusブログ記事の警告を修正

### DIFF
--- a/apps/docs/blog/2025-06-14-dependency-management-strategies.md
+++ b/apps/docs/blog/2025-06-14-dependency-management-strategies.md
@@ -9,6 +9,8 @@ tags: [pnpm, monorepo, dependency-management, renovate, automation]
 
 pnpm + TurboRepoのモノレポ環境で、依存関係を効率的に管理する5つの戦略を比較検討します。
 
+<!-- truncate -->
+
 ## 1. 🤖 Renovate Bot（推奨）
 
 **最も高機能で自動化に優れた選択肢**

--- a/apps/docs/blog/2025-06-14-react19-docusaurus-type-issue.md
+++ b/apps/docs/blog/2025-06-14-react19-docusaurus-type-issue.md
@@ -9,6 +9,8 @@ tags: [react, docusaurus, typescript, bug]
 
 Renovateによる依存関係更新後、DocusaurusのLinkコンポーネントでTypeScriptの型エラーが発生しました。
 
+<!-- truncate -->
+
 ## エラー内容
 
 ```

--- a/apps/docs/blog/2025-06-14-storybook-v9-migration-investigation.md
+++ b/apps/docs/blog/2025-06-14-storybook-v9-migration-investigation.md
@@ -11,6 +11,8 @@ tags: [storybook, migration, frontend-tooling]
 
 Storybook v8.6.14からv9.0.9へのマイグレーションを試行した結果、現時点では安定版への移行が困難であることが判明。
 
+<!-- truncate -->
+
 ## マイグレーション試行内容
 
 ### 実行コマンド

--- a/apps/docs/blog/tags.yml
+++ b/apps/docs/blog/tags.yml
@@ -67,3 +67,48 @@ troubleshooting:
   label: トラブルシューティング
   permalink: /troubleshooting
   description: 問題解決や修正方法に関する記事
+
+dependency-management:
+  label: 依存関係管理
+  permalink: /dependency-management
+  description: パッケージの依存関係管理に関する記事
+
+renovate:
+  label: Renovate
+  permalink: /renovate
+  description: Renovateを使用した自動化に関する記事
+
+automation:
+  label: 自動化
+  permalink: /automation
+  description: 開発プロセスの自動化に関する記事
+
+react:
+  label: React
+  permalink: /react
+  description: React開発に関する記事
+
+docusaurus:
+  label: Docusaurus
+  permalink: /docusaurus
+  description: Docusaurusフレームワークに関する記事
+
+bug:
+  label: バグ
+  permalink: /bug
+  description: バグや不具合に関する記事
+
+storybook:
+  label: Storybook
+  permalink: /storybook
+  description: Storybookに関する記事
+
+migration:
+  label: マイグレーション
+  permalink: /migration
+  description: バージョンアップやマイグレーションに関する記事
+
+frontend-tooling:
+  label: フロントエンドツール
+  permalink: /frontend-tooling
+  description: フロントエンド開発ツールに関する記事


### PR DESCRIPTION
## 概要

Docusaurusブログ記事で発生していた警告を修正しました。

## 変更内容

- 各ブログ記事に `<\!-- truncate -->` コメントを追加
  - リスト表示時の記事抜粋の範囲を明示的に指定
  - これにより、ブログリスト表示時の警告が解消されます

- `tags.yml` に不足していたタグ定義を追加
  - dependency-management, renovate, automation
  - react, docusaurus, bug
  - storybook, migration, frontend-tooling

## テストプラン

- [ ] `pnpm turbo dev --filter=@my-blog/docs` でローカル環境を起動
- [ ] ブログページ（/blog）にアクセスして警告が表示されないことを確認
- [ ] 各ブログ記事のタグページが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)