### PR TITLE
feat(web): ターミナル風デザイン用の等幅フォントを設定

### DIFF
--- a/apps/docs/blog/2025-06-17-font-setup-jetbrains-mono-noto-sans-jp.md
+++ b/apps/docs/blog/2025-06-17-font-setup-jetbrains-mono-noto-sans-jp.md
@@ -1,0 +1,143 @@
+---
+slug: font-setup-jetbrains-mono-noto-sans-jp
+title: ターミナル風デザインのための等幅フォント設定 - JetBrains Mono + Noto Sans JP
+authors: tsuka-ryu
+tags: [fonts, design-system, jetbrains-mono, noto-sans-jp, next.js, storybook, docusaurus]
+---
+
+ターミナル風デザインの技術ブログプロジェクトで、英数字にJetBrains Mono、日本語にNoto Sans JPを組み合わせたフォント設定を実装しました。3つのプラットフォーム（Next.js、Storybook、Docusaurus）で統一したフォント体験を実現する方法を紹介します。
+
+<!-- truncate -->
+
+## フォント選定の理由
+
+### JetBrains Mono（英数字用）
+
+- プログラミング向けに設計された読みやすい等幅フォント
+- ターミナル環境での使用を想定した視認性の高いデザイン
+- Google Fontsで提供されており、Webでの使用が容易
+
+### Noto Sans JP（日本語用）
+
+- Googleが開発した高品質な日本語フォント
+- 等幅フォントとの組み合わせでも違和感の少ないデザイン
+- Google Fontsで提供されており、ロード時間も最適化されている
+
+## 実装方法
+
+### 1. Next.js アプリケーション
+
+`app/layout.tsx`でGoogle Fontsを読み込み、CSS変数として設定：
+
+```tsx
+import { JetBrains_Mono, Noto_Sans_JP } from 'next/font/google';
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+});
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  variable: '--font-noto-sans-jp',
+  display: 'swap',
+  preload: false,
+});
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang='ja'>
+      <body className={`${jetbrainsMono.variable} ${notoSansJP.variable} font-mono`}>
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+### 2. Tailwind CSS 設定
+
+`packages/ui-config/src/tailwind.config.ts`でフォントファミリーを定義：
+
+```typescript
+export const baseConfig: Partial<Config> = {
+  theme: {
+    extend: {
+      fontFamily: {
+        mono: ['var(--font-jetbrains-mono)', 'var(--font-noto-sans-jp)', 'monospace'],
+        sans: ['var(--font-noto-sans-jp)', 'sans-serif'],
+      },
+      // その他の設定...
+    },
+  },
+};
+```
+
+### 3. Storybook 設定
+
+`.storybook/preview.tsx`でdecoratorを使用してフォントを適用：
+
+```tsx
+const preview: Preview = {
+  decorators: [
+    Story => (
+      <>
+        <link rel='preconnect' href='https://fonts.googleapis.com' />
+        <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='anonymous' />
+        <link
+          href='https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap'
+          rel='stylesheet'
+        />
+        <div style={{ fontFamily: "'JetBrains Mono', 'Noto Sans JP', monospace" }}>
+          <Story />
+        </div>
+      </>
+    ),
+  ],
+  // その他の設定...
+};
+```
+
+### 4. Docusaurus 設定
+
+`src/css/custom.css`でInfima変数を使用：
+
+```css
+/* Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
+
+:root {
+  /* Font settings */
+  --ifm-font-family-base: 'JetBrains Mono', 'Noto Sans JP', monospace;
+  --ifm-font-family-monospace: 'JetBrains Mono', 'Noto Sans JP', monospace;
+
+  /* その他の設定... */
+}
+```
+
+## ポイントと注意事項
+
+### 1. フォント読み込み順序
+
+各フォントの指定で、JetBrains Monoを最初に、次にNoto Sans JP、最後にフォールバック（monospace/sans-serif）を指定することで、英数字は等幅フォント、日本語は適切なフォントで表示されます。
+
+### 2. パフォーマンス最適化
+
+- `display: 'swap'`でフォントロード中のテキスト表示を改善
+- `preload: false`で日本語フォントの初期ロードを制御
+- Google Fontsの`&display=swap`パラメータを使用
+
+### 3. プラットフォーム間の統一
+
+3つの異なるプラットフォームで同じフォント体験を実現するため、それぞれのフレームワークの仕組みに合わせた実装を行いました：
+
+- **Next.js**: `next/font/google`とCSS変数
+- **Storybook**: 直接的なGoogle Fontsの読み込み
+- **Docusaurus**: Infima変数システムの活用
+
+## 結果
+
+これらの設定により、ターミナル風デザインに適した統一されたタイポグラフィを3つのプラットフォーム全体で実現できました。英数字はプログラミング向けの読みやすいJetBrains Mono、日本語は美しく読みやすいNoto Sans JPで表示され、ターミナル環境のような一体感のあるデザインが完成しました。
+
+モノレポ環境でのデザインシステム構築において、複数のプラットフォーム間でのフォント統一は重要な要素です。今回の実装パターンは、他のプロジェクトでも応用できる汎用的なアプローチとなっています。

--- a/apps/docs/blog/tags.yml
+++ b/apps/docs/blog/tags.yml
@@ -112,3 +112,28 @@ frontend-tooling:
   label: フロントエンドツール
   permalink: /frontend-tooling
   description: フロントエンド開発ツールに関する記事
+
+fonts:
+  label: フォント
+  permalink: /fonts
+  description: フォント設定やタイポグラフィに関する記事
+
+design-system:
+  label: デザインシステム
+  permalink: /design-system
+  description: デザインシステム構築に関する記事
+
+jetbrains-mono:
+  label: JetBrains Mono
+  permalink: /jetbrains-mono
+  description: JetBrains Monoフォントに関する記事
+
+noto-sans-jp:
+  label: Noto Sans JP
+  permalink: /noto-sans-jp
+  description: Noto Sans JPフォントに関する記事
+
+next.js:
+  label: Next.js
+  permalink: /nextjs
+  description: Next.jsフレームワークに関する記事

--- a/apps/docs/docs/TODO.md
+++ b/apps/docs/docs/TODO.md
@@ -54,7 +54,7 @@ my-blog-with-claude-code/
 
 - [x] **2.1.1** Tailwind CSS セットアップ
 - [x] **2.1.2** ターミナル風カラーパレット定義
-- [ ] **2.1.3** 等幅フォント設定（Monaspace優先）
+- [x] **2.1.3** 等幅フォント設定（JetBrains Mono + Noto Sans JP）
 - [ ] **2.1.4** ダークモード対応（system/dark/light）
 - [ ] **2.1.5** レスポンシブブレークポイント設定
 

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -4,6 +4,9 @@
  * work well for content-centric websites.
  */
 
+/* Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap');
+
 /* You can override the default Infima variables here. */
 :root {
   --ifm-color-primary: #2e8555;
@@ -15,6 +18,10 @@
   --ifm-color-primary-lightest: #3cad6e;
   --ifm-code-font-size: 95%;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  
+  /* Font settings */
+  --ifm-font-family-base: 'Noto Sans JP', sans-serif;
+  --ifm-font-family-monospace: 'JetBrains Mono', 'Noto Sans JP', monospace;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -20,7 +20,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
   
   /* Font settings */
-  --ifm-font-family-base: 'Noto Sans JP', sans-serif;
+  --ifm-font-family-base: 'JetBrains Mono', 'Noto Sans JP', monospace;
   --ifm-font-family-monospace: 'JetBrains Mono', 'Noto Sans JP', monospace;
 }
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,7 +28,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ja'>
-      <body className={`${jetbrainsMono.variable} ${notoSansJP.variable} font-mono`}>
+      <body
+        className={`${jetbrainsMono.variable} ${notoSansJP.variable}`}
+        style={{ fontFamily: 'var(--font-jetbrains-mono), var(--font-noto-sans-jp), monospace' }}
+      >
         {children}
       </body>
     </html>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,10 +28,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='ja'>
-      <body
-        className={`${jetbrainsMono.variable} ${notoSansJP.variable}`}
-        style={{ fontFamily: 'var(--font-jetbrains-mono), var(--font-noto-sans-jp), monospace' }}
-      >
+      <body className={`${jetbrainsMono.variable} ${notoSansJP.variable} font-mono`}>
         {children}
       </body>
     </html>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,15 +1,19 @@
-import localFont from 'next/font/local';
+import { JetBrains_Mono, Noto_Sans_JP } from 'next/font/google';
 
 import type { Metadata } from 'next';
 import './globals.css';
 
-const geistSans = localFont({
-  src: './fonts/GeistVF.woff',
-  variable: '--font-geist-sans',
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
 });
-const geistMono = localFont({
-  src: './fonts/GeistMonoVF.woff',
-  variable: '--font-geist-mono',
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  variable: '--font-noto-sans-jp',
+  display: 'swap',
+  preload: false,
 });
 
 export const metadata: Metadata = {
@@ -23,8 +27,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang='en'>
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>{children}</body>
+    <html lang='ja'>
+      <body className={`${jetbrainsMono.variable} ${notoSansJP.variable} font-mono`}>
+        {children}
+      </body>
     </html>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -37,6 +37,7 @@ export default function Home() {
             Get started by editing <code>apps/web/app/page.tsx</code>
           </li>
           <li>Save and see your changes instantly.</li>
+          <li>日本語のテスト。１２３４1234</li>
         </ol>
 
         <div className={styles.ctas}>

--- a/packages/ui-config/src/tailwind.config.ts
+++ b/packages/ui-config/src/tailwind.config.ts
@@ -3,6 +3,10 @@ import type { Config } from 'tailwindcss';
 export const baseConfig: Partial<Config> = {
   theme: {
     extend: {
+      fontFamily: {
+        mono: ['var(--font-jetbrains-mono)', 'var(--font-noto-sans-jp)', 'monospace'],
+        sans: ['var(--font-noto-sans-jp)', 'sans-serif'],
+      },
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',

--- a/packages/ui/.storybook/preview.tsx
+++ b/packages/ui/.storybook/preview.tsx
@@ -2,6 +2,21 @@ import type { Preview } from '@storybook/react';
 import '../src/styles/globals.css';
 
 const preview: Preview = {
+  decorators: [
+    Story => (
+      <>
+        <link rel='preconnect' href='https://fonts.googleapis.com' />
+        <link rel='preconnect' href='https://fonts.gstatic.com' crossOrigin='anonymous' />
+        <link
+          href='https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&display=swap'
+          rel='stylesheet'
+        />
+        <div style={{ fontFamily: "'JetBrains Mono', 'Noto Sans JP', monospace" }}>
+          <Story />
+        </div>
+      </>
+    ),
+  ],
   parameters: {
     actions: { argTypesRegex: '^on[A-Z].*' },
     controls: {


### PR DESCRIPTION
## Summary
- ターミナル風デザインテーマの実現に向けて、読みやすく統一感のある等幅フォントを導入
- 英数字と日本語それぞれに最適なフォントを選定し、開発者向けブログの読みやすさを向上

## 変更内容
- JetBrains Mono（英数字用）とNoto Sans JP（日本語用）をGoogle Fontsから導入
- Tailwind CSS設定でfont-monoとfont-sansクラスが使用可能に
- apps/web全体に等幅フォントを適用

## 関連タスク
- TODO.mdの2.1.3タスクが完了

## Test plan
- [x] Next.js開発サーバーでフォントが正しく表示されることを確認
- [x] 日本語と英数字が等幅フォントで表示されることを確認
- [x] font-monoとfont-sansクラスが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)