### PR TITLE
feat: axe-core自動アクセシビリティテスト基盤の導入

### DIFF
--- a/packages/ui/src/components/button.test.tsx
+++ b/packages/ui/src/components/button.test.tsx
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 
+import { expectNoA11yViolations } from '../test-utils/accessibility';
+
 import { Button } from './button';
 
 describe('Button', () => {
@@ -90,5 +92,12 @@ describe('Button', () => {
     const ref = React.createRef<HTMLButtonElement>();
     render(<Button ref={ref}>With Ref</Button>);
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  describe('Accessibility', () => {
+    it('should not have accessibility violations', async () => {
+      const { container } = render(<Button>Accessible Button</Button>);
+      await expectNoA11yViolations(container);
+    });
   });
 });

--- a/packages/ui/src/test-utils/accessibility.ts
+++ b/packages/ui/src/test-utils/accessibility.ts
@@ -1,0 +1,82 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { run, type AxeResults } from 'axe-core';
+
+import type { ReactElement } from 'react';
+
+/**
+ * axe-coreを直接使用してアクセシビリティテストを実行
+ */
+const runAxe = async (element: HTMLElement, options = {}): Promise<AxeResults> => {
+  return new Promise((resolve, reject) => {
+    run(element, options, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+};
+
+/**
+ * アクセシビリティテスト用のヘルパー関数
+ */
+export const renderWithAxe = async (
+  ui: ReactElement,
+  options?: RenderOptions
+): Promise<{ container: HTMLElement; axeResults: AxeResults }> => {
+  const { container } = render(ui, options);
+  const axeResults = await runAxe(container);
+
+  return { container, axeResults };
+};
+
+/**
+ * 基本的なアクセシビリティ違反をチェックする
+ * JSdom環境で問題のあるルールを除外
+ */
+export const expectNoA11yViolations = async (element: HTMLElement): Promise<void> => {
+  const results = await runAxe(element, {
+    rules: {
+      // JSdom環境でCanvas APIが利用できないため、color-contrastルールを無効化
+      'color-contrast': { enabled: false },
+    },
+  });
+
+  if (results.violations.length > 0) {
+    const violationMessages = results.violations
+      .map(
+        violation =>
+          `${violation.id}: ${violation.description}\n` +
+          violation.nodes.map(node => `  - ${node.failureSummary}`).join('\n')
+      )
+      .join('\n\n');
+
+    throw new Error(`Accessibility violations found:\n\n${violationMessages}`);
+  }
+};
+
+/**
+ * 特定のルールを除外してアクセシビリティテストを実行する
+ */
+export const runAxeTestWithExclusions = async (
+  element: HTMLElement,
+  excludeRules: string[] = []
+): Promise<AxeResults> => {
+  return await runAxe(element, {
+    rules: excludeRules.reduce(
+      (acc, rule) => {
+        acc[rule] = { enabled: false };
+        return acc;
+      },
+      {} as Record<string, { enabled: boolean }>
+    ),
+  });
+};
+
+/**
+ * カスタムAxe設定でテストを実行する
+ */
+export const runAxeTestWithConfig = async (
+  element: HTMLElement,
+  config = {}
+): Promise<AxeResults> => {
+  return await runAxe(element, config);
+};


### PR DESCRIPTION
## Summary
- axe-coreを使用したアクセシビリティテストユーティリティを作成
- 基本的なアクセシビリティ違反をチェックする`expectNoA11yViolations`関数を実装
- JSdom環境で問題のあるルール（color-contrast）を除外する設定を追加
- Buttonコンポーネントに基本的なアクセシビリティテストを追加

## Test plan
- [x] axe-coreのテストユーティリティが正常に動作すること
- [x] Buttonコンポーネントのアクセシビリティテストがパスすること
- [x] 全てのテストが正常に実行されること

🤖 Generated with [Claude Code](https://claude.ai/code)