### PR TITLE
feat: Linkコンポーネントの単体テスト実装

### DIFF
--- a/packages/ui/src/components/link.test.tsx
+++ b/packages/ui/src/components/link.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { expectNoA11yViolations } from '../test-utils/accessibility';
+
+import { Link } from './link';
+
+describe('Link', () => {
+  it('renders with default props', () => {
+    render(<Link href='/home'>Home</Link>);
+    const link = screen.getByRole('link', { name: 'Home' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/home');
+    expect(link).toHaveClass('text-terminal-accent'); // primary variant
+  });
+
+  it('renders different variants', () => {
+    const { rerender } = render(
+      <Link href='#' variant='secondary'>
+        Secondary
+      </Link>
+    );
+    expect(screen.getByRole('link')).toHaveClass('text-terminal-text-primary');
+
+    rerender(
+      <Link href='#' variant='muted'>
+        Muted
+      </Link>
+    );
+    expect(screen.getByRole('link')).toHaveClass('text-terminal-text-muted');
+
+    rerender(
+      <Link href='#' variant='underline'>
+        Underline
+      </Link>
+    );
+    expect(screen.getByRole('link')).toHaveClass('underline');
+  });
+
+  it('handles external links', () => {
+    render(
+      <Link href='https://example.com' external>
+        External Link
+      </Link>
+    );
+    const link = screen.getByRole('link', { name: /External Link/ });
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+
+    // Check for external link icon
+    expect(screen.getByLabelText('(外部リンク)')).toBeInTheDocument();
+  });
+
+  it('handles unstyled prop', () => {
+    render(
+      <Link href='#' unstyled>
+        Unstyled Link
+      </Link>
+    );
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('transition-colors');
+    expect(link).not.toHaveClass('text-terminal-accent');
+  });
+
+  it('applies custom className', () => {
+    render(
+      <Link href='#' className='custom-link-class'>
+        Custom
+      </Link>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('custom-link-class');
+    expect(link).toHaveClass('text-terminal-accent'); // Still has variant styles
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = React.createRef<HTMLAnchorElement>();
+    render(
+      <Link href='#' ref={ref}>
+        With Ref
+      </Link>
+    );
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
+  });
+
+  it('handles undefined href', () => {
+    render(<Link>No Href</Link>);
+    const link = screen.getByText('No Href');
+    expect(link.tagName).toBe('A');
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <Link href='#' data-testid='test-link' title='Test Link Title'>
+        Test Link
+      </Link>
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('data-testid', 'test-link');
+    expect(link).toHaveAttribute('title', 'Test Link Title');
+  });
+
+  describe('Accessibility', () => {
+    it('should not have accessibility violations', async () => {
+      const { container } = render(<Link href='/accessible'>Accessible Link</Link>);
+      await expectNoA11yViolations(container);
+    });
+
+    it('should not have accessibility violations with external link', async () => {
+      const { container } = render(
+        <Link href='https://example.com' external>
+          External Link
+        </Link>
+      );
+      await expectNoA11yViolations(container);
+    });
+
+    it('has proper focus styles', () => {
+      render(<Link href='#'>Focusable Link</Link>);
+      const link = screen.getByRole('link');
+      expect(link).toHaveClass('focus:outline-none');
+      expect(link).toHaveClass('focus:ring-2');
+      expect(link).toHaveClass('focus:ring-terminal-ui-border-focus');
+    });
+
+    it('external link icon has proper aria attributes', () => {
+      render(
+        <Link href='https://example.com' external>
+          External
+        </Link>
+      );
+      const icon = screen.getByLabelText('(外部リンク)').querySelector('svg');
+      expect(icon).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+});

--- a/packages/ui/src/test-utils/accessibility.ts
+++ b/packages/ui/src/test-utils/accessibility.ts
@@ -1,0 +1,82 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { run, type AxeResults } from 'axe-core';
+
+import type { ReactElement } from 'react';
+
+/**
+ * axe-coreを直接使用してアクセシビリティテストを実行
+ */
+const runAxe = async (element: HTMLElement, options = {}): Promise<AxeResults> => {
+  return new Promise((resolve, reject) => {
+    run(element, options, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+};
+
+/**
+ * アクセシビリティテスト用のヘルパー関数
+ */
+export const renderWithAxe = async (
+  ui: ReactElement,
+  options?: RenderOptions
+): Promise<{ container: HTMLElement; axeResults: AxeResults }> => {
+  const { container } = render(ui, options);
+  const axeResults = await runAxe(container);
+
+  return { container, axeResults };
+};
+
+/**
+ * 基本的なアクセシビリティ違反をチェックする
+ * JSdom環境で問題のあるルールを除外
+ */
+export const expectNoA11yViolations = async (element: HTMLElement): Promise<void> => {
+  const results = await runAxe(element, {
+    rules: {
+      // JSdom環境でCanvas APIが利用できないため、color-contrastルールを無効化
+      'color-contrast': { enabled: false },
+    },
+  });
+
+  if (results.violations.length > 0) {
+    const violationMessages = results.violations
+      .map(
+        violation =>
+          `${violation.id}: ${violation.description}\n` +
+          violation.nodes.map(node => `  - ${node.failureSummary}`).join('\n')
+      )
+      .join('\n\n');
+
+    throw new Error(`Accessibility violations found:\n\n${violationMessages}`);
+  }
+};
+
+/**
+ * 特定のルールを除外してアクセシビリティテストを実行する
+ */
+export const runAxeTestWithExclusions = async (
+  element: HTMLElement,
+  excludeRules: string[] = []
+): Promise<AxeResults> => {
+  return await runAxe(element, {
+    rules: excludeRules.reduce(
+      (acc, rule) => {
+        acc[rule] = { enabled: false };
+        return acc;
+      },
+      {} as Record<string, { enabled: boolean }>
+    ),
+  });
+};
+
+/**
+ * カスタムAxe設定でテストを実行する
+ */
+export const runAxeTestWithConfig = async (
+  element: HTMLElement,
+  config = {}
+): Promise<AxeResults> => {
+  return await runAxe(element, config);
+};


### PR DESCRIPTION
## Summary
- Linkコンポーネントの包括的な単体テストを実装
- 4つのvariant（primary, secondary, muted, underline）のテスト
- 外部リンク機能（target="_blank"、rel="noopener noreferrer"、アイコン表示）のテスト
- unstyledプロパティ、refフォワーディングのテスト
- アクセシビリティテスト（フォーカススタイル、aria属性）を実施

## Test plan
- [x] 全てのvariantが正しくスタイルを適用すること
- [x] 外部リンクが適切な属性とアイコンを持つこと
- [x] unstyledプロパティでスタイルが除去されること
- [x] フォーカススタイルが適切に適用されること
- [x] アクセシビリティ違反がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)