### PR TITLE
feat: Loadingコンポーネントの単体テスト実装とアクセシビリティ改善

### DIFF
--- a/packages/ui/src/components/loading.test.tsx
+++ b/packages/ui/src/components/loading.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+
+import { expectNoA11yViolations } from '../test-utils/accessibility';
+
+import { Loading } from './loading';
+
+describe('Loading', () => {
+  it('renders with default props', () => {
+    render(<Loading />);
+    const loading = screen.getByRole('status');
+    expect(loading).toBeInTheDocument();
+    expect(loading).toHaveAttribute('aria-label', '読み込み中');
+    expect(loading).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('renders different variants', () => {
+    const { rerender } = render(<Loading variant='spinner' />);
+    expect(screen.getByRole('status').querySelector('.animate-spin')).toBeInTheDocument();
+
+    rerender(<Loading variant='pulse' />);
+    expect(screen.getByRole('status').querySelector('.animate-pulse')).toBeInTheDocument();
+
+    rerender(<Loading variant='skeleton' />);
+    const skeleton = screen.getByRole('status');
+    expect(skeleton.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    expect(skeleton.querySelectorAll('.h-4').length).toBe(3);
+  });
+
+  it('renders different sizes', () => {
+    const { rerender } = render(<Loading size='sm' />);
+    expect(screen.getByRole('status').querySelector('.w-4')).toBeInTheDocument();
+
+    rerender(<Loading size='md' />);
+    expect(screen.getByRole('status').querySelector('.w-8')).toBeInTheDocument();
+
+    rerender(<Loading size='lg' />);
+    expect(screen.getByRole('status').querySelector('.w-12')).toBeInTheDocument();
+  });
+
+  it('renders with text', () => {
+    render(<Loading text='データを読み込んでいます...' />);
+    const loading = screen.getByRole('status');
+    expect(loading).toHaveAttribute('aria-label', 'データを読み込んでいます...');
+
+    const textElement = screen.getByText('データを読み込んでいます...');
+    expect(textElement).toBeInTheDocument();
+    expect(textElement).toHaveAttribute('aria-live', 'polite');
+    expect(textElement).toHaveClass('font-mono');
+  });
+
+  it('applies different text sizes based on size prop', () => {
+    const { rerender } = render(<Loading size='sm' text='Loading...' />);
+    expect(screen.getByText('Loading...')).toHaveClass('text-sm');
+
+    rerender(<Loading size='md' text='Loading...' />);
+    expect(screen.getByText('Loading...')).toHaveClass('text-base');
+
+    rerender(<Loading size='lg' text='Loading...' />);
+    expect(screen.getByText('Loading...')).toHaveClass('text-lg');
+  });
+
+  it('applies custom className', () => {
+    render(<Loading className='custom-loading' />);
+    const innerDiv = screen.getByRole('status').firstElementChild;
+    expect(innerDiv).toHaveClass('custom-loading');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(<Loading ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes through additional props', () => {
+    render(<Loading data-testid='loading-indicator' />);
+    const innerDiv = screen.getByRole('status').firstElementChild;
+    expect(innerDiv).toHaveAttribute('data-testid', 'loading-indicator');
+  });
+
+  describe('Accessibility', () => {
+    it('should not have accessibility violations for spinner', async () => {
+      const { container } = render(<Loading variant='spinner' />);
+      await expectNoA11yViolations(container);
+    });
+
+    it('should not have accessibility violations for pulse', async () => {
+      const { container } = render(<Loading variant='pulse' />);
+      await expectNoA11yViolations(container);
+    });
+
+    it('should not have accessibility violations for skeleton', async () => {
+      const { container } = render(<Loading variant='skeleton' />);
+      await expectNoA11yViolations(container);
+    });
+
+    it('should not have accessibility violations with text', async () => {
+      const { container } = render(<Loading text='Processing...' />);
+      await expectNoA11yViolations(container);
+    });
+
+    it('has proper ARIA attributes', () => {
+      render(<Loading />);
+      const loading = screen.getByRole('status');
+      expect(loading).toHaveAttribute('aria-live', 'polite');
+      expect(loading).toHaveAttribute('aria-label');
+    });
+
+    it('text element has aria-live attribute', () => {
+      render(<Loading text='Please wait...' />);
+      const textElement = screen.getByText('Please wait...');
+      expect(textElement).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+});

--- a/packages/ui/src/components/loading.tsx
+++ b/packages/ui/src/components/loading.tsx
@@ -26,16 +26,12 @@ const Loading = forwardRef<HTMLDivElement, LoadingProps>(
     const renderSpinner = () => (
       <div
         className={`animate-spin rounded-full border-2 border-gray-300 border-t-green-400 dark:border-gray-600 dark:border-t-green-400 ${sizeClasses[size]}`}
-        role='status'
-        aria-label='読み込み中'
       />
     );
 
     const renderPulse = () => (
       <div
         className={`animate-pulse rounded-full bg-gray-300 dark:bg-gray-600 ${sizeClasses[size]}`}
-        role='status'
-        aria-label='読み込み中'
       />
     );
 

--- a/packages/ui/src/test-utils/accessibility.ts
+++ b/packages/ui/src/test-utils/accessibility.ts
@@ -1,0 +1,82 @@
+import { render, type RenderOptions } from '@testing-library/react';
+import { run, type AxeResults } from 'axe-core';
+
+import type { ReactElement } from 'react';
+
+/**
+ * axe-coreを直接使用してアクセシビリティテストを実行
+ */
+const runAxe = async (element: HTMLElement, options = {}): Promise<AxeResults> => {
+  return new Promise((resolve, reject) => {
+    run(element, options, (err, results) => {
+      if (err) reject(err);
+      else resolve(results);
+    });
+  });
+};
+
+/**
+ * アクセシビリティテスト用のヘルパー関数
+ */
+export const renderWithAxe = async (
+  ui: ReactElement,
+  options?: RenderOptions
+): Promise<{ container: HTMLElement; axeResults: AxeResults }> => {
+  const { container } = render(ui, options);
+  const axeResults = await runAxe(container);
+
+  return { container, axeResults };
+};
+
+/**
+ * 基本的なアクセシビリティ違反をチェックする
+ * JSdom環境で問題のあるルールを除外
+ */
+export const expectNoA11yViolations = async (element: HTMLElement): Promise<void> => {
+  const results = await runAxe(element, {
+    rules: {
+      // JSdom環境でCanvas APIが利用できないため、color-contrastルールを無効化
+      'color-contrast': { enabled: false },
+    },
+  });
+
+  if (results.violations.length > 0) {
+    const violationMessages = results.violations
+      .map(
+        violation =>
+          `${violation.id}: ${violation.description}\n` +
+          violation.nodes.map(node => `  - ${node.failureSummary}`).join('\n')
+      )
+      .join('\n\n');
+
+    throw new Error(`Accessibility violations found:\n\n${violationMessages}`);
+  }
+};
+
+/**
+ * 特定のルールを除外してアクセシビリティテストを実行する
+ */
+export const runAxeTestWithExclusions = async (
+  element: HTMLElement,
+  excludeRules: string[] = []
+): Promise<AxeResults> => {
+  return await runAxe(element, {
+    rules: excludeRules.reduce(
+      (acc, rule) => {
+        acc[rule] = { enabled: false };
+        return acc;
+      },
+      {} as Record<string, { enabled: boolean }>
+    ),
+  });
+};
+
+/**
+ * カスタムAxe設定でテストを実行する
+ */
+export const runAxeTestWithConfig = async (
+  element: HTMLElement,
+  config = {}
+): Promise<AxeResults> => {
+  return await runAxe(element, config);
+};


### PR DESCRIPTION
## Summary
### テスト実装
- 3つのvariant（spinner, pulse, skeleton）のテスト
- サイズ（sm, md, lg）のテスト
- テキスト表示機能のテスト
- refフォワーディング、カスタムclassNameのテスト
- axe-coreによる包括的なアクセシビリティテスト

### コンポーネント改善
- 重複していた`role='status'`属性を修正
- 外側のコンテナのみに`role='status'`を設定し、内部要素から削除
- これによりスクリーンリーダーでの読み上げが正しく動作するように改善

### アクセシビリティ
- 適切なARIA属性（`aria-label`, `aria-live='polite'`）を確保
- テキスト要素にも`aria-live`属性を設定し、動的な更新を通知

## Test plan
- [x] 全てのvariantが正しくレンダリングされること
- [x] サイズプロパティが適切なクラスを適用すること
- [x] テキストが表示され、適切なARIA属性を持つこと
- [x] コンポーネントの修正後もアクセシビリティ違反がないこと

🤖 Generated with [Claude Code](https://claude.ai/code)