### PR TITLE
fix(ui): post-card.storiesのTypeScriptエラー修正

### DIFF
--- a/packages/ui/src/components/post-card.stories.tsx
+++ b/packages/ui/src/components/post-card.stories.tsx
@@ -1,6 +1,3 @@
-// TODO: Fix type errors - temporarily ignoring typecheck
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import { PostCard } from './post-card';
 
 import type { BlogPostSummary } from '@repo/utils';


### PR DESCRIPTION
## Summary
- @ts-nocheckディレクティブを削除し、型安全性を復元
- PostCardコンポーネントとBlogPostSummary型の互換性を確認済み
- 実際にはTypeScriptエラーは発生しておらず、@ts-nocheckが不要であることを確認

## Test plan
- [x] TypeScriptエラーがないことを確認
- [x] pnpm turbo lintでlintチェック通過
- [x] pnpm turbo check-typesで型チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)